### PR TITLE
Ability to select an album and play it's content!

### DIFF
--- a/app/src/main/java/com/example/tacomamusicplayer/fragment/MusicPlayingFragment.kt
+++ b/app/src/main/java/com/example/tacomamusicplayer/fragment/MusicPlayingFragment.kt
@@ -1,5 +1,6 @@
 package com.example.tacomamusicplayer.fragment
 
+import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -7,9 +8,12 @@ import android.view.ViewGroup
 import androidx.annotation.OptIn
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.media3.common.MediaItem
 import androidx.media3.common.util.UnstableApi
+import androidx.media3.session.MediaController
 import androidx.navigation.fragment.findNavController
 import androidx.viewpager2.widget.ViewPager2
+import com.example.tacomamusicplayer.R
 import com.example.tacomamusicplayer.adapter.ScreenSlidePagerAdapter
 import com.example.tacomamusicplayer.databinding.FragmentMusicPlayingBinding
 import com.example.tacomamusicplayer.enum.ScreenType
@@ -22,6 +26,8 @@ class MusicPlayingFragment: Fragment() {
     private val parentViewModel: MainViewModel by activityViewModels()
 
     private lateinit var binding: FragmentMusicPlayingBinding
+
+    private var controller: MediaController? = null
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -36,11 +42,27 @@ class MusicPlayingFragment: Fragment() {
     @OptIn(UnstableApi::class) override fun onStart() {
         super.onStart()
 
-
-
         parentViewModel.mediaController.observe(this) { controller ->
             binding.playerView.player = controller
+            this.controller = controller
             binding.playerView.showController()
+        }
+
+        parentViewModel.currentSongList.observe(this) { songs ->
+            Timber.d("onStart: CHANGING controller songs to be songs.size=${songs.size}")
+            controller?.clearMediaItems()
+            controller?.addMediaItems(songs)
+            //controller?.addMediaItem(songs[0])
+//            val a = controller?.availableCommands
+//            val b = controller?.availableSessionCommands
+//            val c = "bruhg"
+            //controller?.prepare()
+//            val pkgName = this@MusicPlayingFragment.context?.let {
+//                val path = Uri.parse("android.resource://" + it.packageName + "/" + R.raw.earth)
+//                controller?.addMediaItem(MediaItem.fromUri(path))
+//                controller?.prepare()
+//                //TODO if controller is null and songs are not...
+//            }
         }
 
 

--- a/app/src/main/java/com/example/tacomamusicplayer/service/MusicService.kt
+++ b/app/src/main/java/com/example/tacomamusicplayer/service/MusicService.kt
@@ -1,7 +1,6 @@
 package com.example.tacomamusicplayer.service
 
 import android.content.Intent
-import android.net.Uri
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
@@ -13,7 +12,6 @@ import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.session.LibraryResult
 import androidx.media3.session.MediaLibraryService
 import androidx.media3.session.MediaSession
-import com.example.tacomamusicplayer.R
 import com.example.tacomamusicplayer.util.MediaStoreUtil
 import com.google.common.collect.ImmutableList
 import com.google.common.util.concurrent.Futures
@@ -46,8 +44,10 @@ class MusicService : MediaLibraryService() {
             controller: MediaSession.ControllerInfo,
             mediaItems: MutableList<MediaItem>
         ): ListenableFuture<MutableList<MediaItem>> {
-            return super.onAddMediaItems(mediaSession, controller, mediaItems)
 
+            //Technically this is a security breach... exposes on device uri to mediacontrollers...
+            val updatedMediaItems = mediaItems.map { it -> it.buildUpon().setUri(it.mediaId).build() }.toMutableList()
+            return Futures.immediateFuture(updatedMediaItems)
         }
 
         override fun onGetLibraryRoot(
@@ -128,15 +128,17 @@ class MusicService : MediaLibraryService() {
 
         player = playerBuilder.build()
 
+        val a = player.availableCommands
+
         player.addListener(PlayerEventListener())
         player.playWhenReady = false //this can be a variable
 
-        val pkgName = applicationContext.packageName
-        //path for local file...
-        val path = Uri.parse("android.resource://" + pkgName + "/" + R.raw.earth)
+//        val pkgName = applicationContext.packageName
+//        //path for local file...
+//        val path = Uri.parse("android.resource://" + pkgName + "/" + R.raw.earth)
 
         //Test code that sets media Items with three of the same -> ui should choose music instead.
-        player.setMediaItems(listOf(MediaItem.fromUri(path), MediaItem.fromUri(path), MediaItem.fromUri(path)))
+        player.setMediaItems(listOf())
         player.prepare()
         return true
     }

--- a/app/src/main/java/com/example/tacomamusicplayer/util/MediaStoreUtil.kt
+++ b/app/src/main/java/com/example/tacomamusicplayer/util/MediaStoreUtil.kt
@@ -58,7 +58,7 @@ class MediaStoreUtil {
                 val songId = cursor.getLong(6)
                 val artworkUri = ContentUris.withAppendedId(uriExternal, songId)
 
-                val songMediaItem = createSongMediaItem(songTitle = title, albumTitle = album, artist = artist, artworkUri = artworkUri, trackNumber = track)
+                val songMediaItem = createSongMediaItem(songUri = url, songTitle = title, albumTitle = album, artist = artist, artworkUri = artworkUri, trackNumber = track)
                 albumSongs.add(songMediaItem)
             }
         }
@@ -124,6 +124,7 @@ class MediaStoreUtil {
      * @return A MediaItem with the associated data.
      */
     private fun createSongMediaItem(
+        songUri: String = "UNKNOWN URI", //I'm adding the Uri to be mediaid however this is going to be a security breach...
         songTitle: String = "UNKONWN SONG TITLE",
         albumTitle: String = "UNKNOWN ALBUM",
         artist: String = "UNKNOWN ARTIST",
@@ -131,7 +132,7 @@ class MediaStoreUtil {
         trackNumber: Int
     ): MediaItem {
         return MediaItem.Builder()
-            .setMediaId(songTitle)
+            .setMediaId(songUri)
             .setMediaMetadata(
                 MediaMetadata.Builder()
                     .setIsBrowsable(false)


### PR DESCRIPTION
Clicking on an album will clear the current media items, and add the album songs into the player. 

The only concession I had to make was using the media item Id as the same as the URI. 
Usually the service will delete the URI as a security issue. However, I'm adding URI as ID so that defeats that purpose. I will have to investigate the correct way to do this more...