### PR TITLE
Fix Claude Regressions from LiveData to StateFlow transition

### DIFF
--- a/app/src/main/java/com/andaagii/tacomamusicplayer/fragment/pages/MusicPlayingFragment.kt
+++ b/app/src/main/java/com/andaagii/tacomamusicplayer/fragment/pages/MusicPlayingFragment.kt
@@ -77,11 +77,6 @@ class MusicPlayingFragment : Fragment() {
                     this@MusicPlayingFragment.controller = controller
                     binding.playerView.showController()
                     updateUIForCurrentSong()
-                    if (controller.isPlaying) {
-                        binding.playButton?.setBackgroundResource(R.drawable.baseline_pause_24)
-                    } else {
-                        binding.playButton?.setBackgroundResource(R.drawable.baseline_play_arrow_24)
-                    }
                 }
             }
         }

--- a/app/src/main/java/com/andaagii/tacomamusicplayer/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/andaagii/tacomamusicplayer/viewmodel/MainViewModel.kt
@@ -952,6 +952,7 @@ class MainViewModel @Inject constructor(
      * asynchronous; the ViewModel updates [mediaController] and [mediaBrowser] once they resolve.
      */
     fun initializeMusicPlaying() {
+        if (_mediaController.value != null) return
         Timber.d("initializeMusicPlaying: ")
         sessionToken = createSessionToken()
         setupMediaController(sessionToken)


### PR DESCRIPTION
- I asked Claude to move from LiveData to StateFlow so that I can start switching to compose from views based android. 
- Regression 1) Music Player briefly pauses when coming from the background.
- Regression 2) Music Player sometimes doesn't update main player when switching songs.